### PR TITLE
Adds name property for getJobs method

### DIFF
--- a/cupsconnection.c
+++ b/cupsconnection.c
@@ -1594,10 +1594,10 @@ Connection_getJobs (Connection *self, PyObject *args, PyObject *kwds)
   request = ippNewRequest(IPP_GET_JOBS);
 
   if (name == NULL) {
-    name = ""
+    name = "";
   }
 
-  char *printerUri = strcat("ipp://localhost/printers/", name)
+  char *printerUri = strcat("ipp://localhost/printers/", name);
 
   ippAddString (request, IPP_TAG_OPERATION, IPP_TAG_URI, "printer-uri",
 		NULL, printerUri);

--- a/cupsconnection.c
+++ b/cupsconnection.c
@@ -1574,6 +1574,7 @@ Connection_getJobs (Connection *self, PyObject *args, PyObject *kwds)
   PyObject *result;
   ipp_t *request, *answer;
   ipp_attribute_t *attr;
+  char *name = NULL;
   char *which = NULL;
   int my_jobs = 0;
   int limit = -1;
@@ -1581,18 +1582,25 @@ Connection_getJobs (Connection *self, PyObject *args, PyObject *kwds)
   PyObject *requested_attrs = NULL;
   char **attrs = NULL; /* initialised to calm compiler */
   size_t n_attrs = 0; /* initialised to calm compiler */
-  static char *kwlist[] = { "which_jobs", "my_jobs", "limit", "first_job_id", 
+  static char *kwlist[] = { "name", "which_jobs", "my_jobs", "limit", "first_job_id", 
 			    "requested_attributes", NULL };
-  if (!PyArg_ParseTupleAndKeywords (args, kwds, "|siiiO", kwlist,
-				    &which, &my_jobs, &limit, &first_job_id,
+  if (!PyArg_ParseTupleAndKeywords (args, kwds, "|ssiiiO", kwlist,
+				    &name, &which, &my_jobs, &limit, &first_job_id,
 				    &requested_attrs))
     return NULL;
 
   debugprintf ("-> Connection_getJobs(%s,%d)\n",
 	       which ? which : "(null)", my_jobs);
   request = ippNewRequest(IPP_GET_JOBS);
+
+  if (name == NULL) {
+    name = ""
+  }
+
+  char *printerUri = strcat("ipp://localhost/printers/", name)
+
   ippAddString (request, IPP_TAG_OPERATION, IPP_TAG_URI, "printer-uri",
-		NULL, "ipp://localhost/printers/");
+		NULL, printerUri);
 
   ippAddString (request, IPP_TAG_OPERATION, IPP_TAG_KEYWORD, "which-jobs",
 		NULL, which ? which : "not-completed");

--- a/cupsconnection.c
+++ b/cupsconnection.c
@@ -1576,6 +1576,7 @@ Connection_getJobs (Connection *self, PyObject *args, PyObject *kwds)
   ipp_attribute_t *attr;
   char *name = NULL;
   char *which = NULL;
+  char uri[1024];
   int my_jobs = 0;
   int limit = -1;
   int first_job_id = -1;
@@ -1597,10 +1598,10 @@ Connection_getJobs (Connection *self, PyObject *args, PyObject *kwds)
     name = "";
   }
 
-  char *printerUri = strcat("ipp://localhost/printers/", name);
+  snprintf (uri, sizeof (uri), "ipp://localhost/printers/%s", name);
 
   ippAddString (request, IPP_TAG_OPERATION, IPP_TAG_URI, "printer-uri",
-		NULL, printerUri);
+		NULL, uri);
 
   ippAddString (request, IPP_TAG_OPERATION, IPP_TAG_KEYWORD, "which-jobs",
 		NULL, which ? which : "not-completed");


### PR DESCRIPTION
In original cups documentation they allow you to specify a name to view the queue of a printer, pycups only allows you originally to see jobs across all queues. I've now exposed an extra `name` kwarg which if specified with the name of a printer will filter it to the jobs of that printer.